### PR TITLE
refactor: add job-level permissions to workflows

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -1,6 +1,4 @@
 name: Bash tests
-permissions:
-  contents: read
 
 on:
   push:
@@ -15,6 +13,8 @@ jobs:
     if: |
       ! contains(github.event.head_commit.message, '[ci skip]') &&
       ! contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/git_mirror.yml
+++ b/.github/workflows/git_mirror.yml
@@ -1,7 +1,5 @@
 name: Mirror to Codeberg and GitLab
 
-permissions:
-  contents: read
 
 on:
   push:
@@ -10,6 +8,8 @@ on:
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: ffflorian/actions/git-mirror@baf8fb2e65ebe6564870f56315a09bc01ab7e0f7
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,4 @@
 name: Go tests
-permissions:
-  contents: read
 
 on:
   push:
@@ -15,6 +13,8 @@ jobs:
     if: |
       ! contains(github.event.head_commit.message, '[ci skip]') &&
       ! contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -1,6 +1,4 @@
 name: JavaScript tests
-permissions:
-  contents: read
 
 on:
   push:
@@ -15,6 +13,8 @@ jobs:
     if: |
       ! contains(github.event.head_commit.message, '[ci skip]') &&
       ! contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,4 @@
 name: Update project numbers
-permissions:
-  contents: write
 
 on:
   push:
@@ -14,6 +12,8 @@ jobs:
     if: |
       ! contains(github.event.head_commit.message, '[ci skip]') &&
       ! contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,4 @@
 name: Python tests
-permissions:
-  contents: read
 
 on:
   push:
@@ -15,6 +13,8 @@ jobs:
     if: |
       ! contains(github.event.head_commit.message, '[ci skip]') &&
       ! contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,4 @@
 name: Rust tests
-permissions:
-  contents: read
 
 on:
   push:
@@ -18,6 +16,8 @@ jobs:
     if: |
       ! contains(github.event.head_commit.message, '[ci skip]') &&
       ! contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,6 +1,4 @@
 name: TypeScript tests
-permissions:
-  contents: read
 
 on:
   push:
@@ -15,6 +13,8 @@ jobs:
     if: |
       ! contains(github.event.head_commit.message, '[ci skip]') &&
       ! contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/yarn_update.yml
+++ b/.github/workflows/yarn_update.yml
@@ -1,8 +1,5 @@
 name: Check for yarn updates
 
-permissions:
-  contents: write
-  pull-requests: write
 
 on:
   schedule:
@@ -17,6 +14,8 @@ on:
 jobs:
   yarn-update-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Update yarn
         uses: ffflorian/actions/yarn-update@baf8fb2e65ebe6564870f56315a09bc01ab7e0f7


### PR DESCRIPTION
Remove global permissions blocks and add job-specific permissions to all workflows.

Each job now includes appropriate permissions based on its operations:
- Standard jobs: contents: read
- Publishing jobs: id-token: write, contents: write
- Security jobs: security-events: write, packages: read, actions: read

Follows GitHub Security Hardening best practices:
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs